### PR TITLE
Just a quick optimization for blockFinder().

### DIFF
--- a/src/main/java/com/xray/common/reference/OreInfo.java
+++ b/src/main/java/com/xray/common/reference/OreInfo.java
@@ -10,6 +10,12 @@ public class OreInfo
 	public String displayName;
 	public String catName;
 
+        public OreInfo( int id, int meta)
+        {
+            this.id = id;
+            this.meta = meta;
+        }
+
 	public OreInfo( String name, int[] color, boolean draw ) {
 		this.oreName = name;
 		this.displayName = "";
@@ -64,4 +70,20 @@ public class OreInfo
 	{
 		this.draw = true;
 	}
+
+        @Override
+        public int hashCode()
+        {
+                return 37 * id + meta;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+                if (o == null) return false;
+                if (this == o) return true;
+                if (!(o instanceof OreInfo)) return false;
+                OreInfo t = (OreInfo) o;
+                return id == t.id && meta == t.meta;
+        }
 }


### PR DESCRIPTION
Hi Michael,
Here's a quick little optimization for ClientTick.blockFinder().
Basically,
- adding final keywords to help the compiler doing its magic
- using BlockPos.getAllInBoxMutable() instead of triple for loop
- using a Map to search for ores rather than a List

This gives me about 10% improvement on calls to blockFinder() (tested with all default ores enabled and a radius of 256).

That's far from a real optimization but well, it's a start isn't it? :)