### PR TITLE
Threads

### DIFF
--- a/src/main/java/com/xray/client/KeyBindingHandler.java
+++ b/src/main/java/com/xray/client/KeyBindingHandler.java
@@ -13,7 +13,7 @@ import com.xray.client.gui.GuiList;
 public class KeyBindingHandler
 {
 	private Minecraft mc = Minecraft.getMinecraft();
-	
+
 	@SubscribeEvent
 	public void onKeyInput( KeyInputEvent event )
     {
@@ -21,8 +21,8 @@ public class KeyBindingHandler
         {
 			if( XRay.keyBind_keys[ XRay.keyIndex_toggleXray ].isPressed() )
 			{
-				XRay.drawOres = !XRay.drawOres;
 				XrayRenderer.ores.clear();
+				XRay.toggleDrawOres();
 			}
 			else if( XRay.keyBind_keys[ XRay.keyIndex_showXrayMenu ].isPressed() )
 			{

--- a/src/main/java/com/xray/client/XRayEventHandler.java
+++ b/src/main/java/com/xray/client/XRayEventHandler.java
@@ -1,0 +1,61 @@
+package com.xray.client;
+
+import com.xray.client.render.XrayRenderer;
+import com.xray.common.XRay;
+import com.xray.common.reference.BlockInfo;
+import com.xray.common.reference.OreInfo;
+import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.math.BlockPos;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+/**
+ * Just a helper class to move away events from ClientTick
+ * (which is instantiated often due to threads)
+ */
+public class XRayEventHandler
+{
+	private static final Minecraft mc = Minecraft.getMinecraft();
+
+	@SubscribeEvent
+	public void pickupItem( BlockEvent.BreakEvent event )
+	{
+		checkBlock( event.getPos(), event.getState(), false);
+	}
+
+	@SubscribeEvent
+	public void placeItem( BlockEvent.PlaceEvent event )
+	{
+		checkBlock( event.getPos(), event.getState(), true);
+	}
+
+	private static void checkBlock( BlockPos pos, IBlockState state, boolean add )
+	{
+		if ( !XRay.drawOres() ) return; // just pass
+
+		// Let's start with getting data (id, meta)
+		Block block = state.getBlock();
+		int id = Block.getIdFromBlock( block );
+		int meta = block.getMetaFromState( state );
+
+		// Let's see if the block to check is an ore we monitor
+		OreInfo key = new OreInfo(id, meta);
+		OreInfo ore = null;
+		for ( OreInfo o : XRay.searchList ) {
+			if ( key.equals(o) && o.draw )
+			{
+				ore = o;
+				break;
+			}
+		}
+		if ( ore != null ) // it's a block we are monitoring
+		{
+			if ( add )	// the block was added to the world, let's add it to the drawing buffer
+				XrayRenderer.ores.add( new BlockInfo(pos, ore.color) );
+			else		// it was removed from the world, let's remove it from the buffer as well
+				XrayRenderer.ores.remove( new BlockInfo(pos, null) );
+		}
+	}
+}

--- a/src/main/java/com/xray/client/gui/GuiList.java
+++ b/src/main/java/com/xray/client/gui/GuiList.java
@@ -2,7 +2,6 @@ package com.xray.client.gui;
 
 import com.xray.client.gui.helper.HelperBlock;
 import com.xray.client.gui.helper.HelperGuiList;
-import com.xray.client.render.ClientTick;
 import com.xray.common.XRay;
 import com.xray.common.config.ConfigHandler;
 import com.xray.common.reference.OreInfo;
@@ -87,11 +86,11 @@ public class GuiList extends GuiContainer
 
         if( pageCurrent == 0 )
         	aPrevButton.enabled = false;
-        
+
         if( pageCurrent == pageMax )
             aNextButton.enabled = false;
     }
-	
+
 	@Override
 	public void actionPerformed( GuiButton button )
 	{
@@ -105,7 +104,7 @@ public class GuiList extends GuiContainer
 				else
 					XRay.currentDist = 0;
 
-				ClientTick.blockFinder( true );
+				XRay.requestBlockFinder( true );
 				ConfigHandler.update("searchdist", false);
 				break;
 
@@ -192,7 +191,7 @@ public class GuiList extends GuiContainer
 					if( list.getButton().id == button.id ) {
 						list.getOre().draw = !list.getOre().draw;
 						ConfigHandler.update( list.getOre().getOreName(), list.getOre().draw );
-						ClientTick.blockFinder( true );
+						XRay.requestBlockFinder( true );
 					}
 				}
 			break;
@@ -223,12 +222,12 @@ public class GuiList extends GuiContainer
 					XRay.currentDist = XRay.distNumbers.length - 1;
 
 				distButtons.displayString = I18n.format("xray.input.distance")+": "+ String.valueOf(XRay.distNumbers[XRay.currentDist]);
-				ClientTick.blockFinder( true );
+				XRay.requestBlockFinder( true );
 				ConfigHandler.update("searchdist", false);
 			}
 		}
 	}
-	
+
 	@Override
 	public void drawScreen( int x, int y, float f ) {
 

--- a/src/main/java/com/xray/client/render/ClientTick.java
+++ b/src/main/java/com/xray/client/render/ClientTick.java
@@ -5,9 +5,6 @@ import java.util.List;
 
 import com.xray.common.XRay;
 import net.minecraft.block.state.IBlockState;
-import net.minecraft.util.math.MathHelper;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
@@ -20,158 +17,108 @@ import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
 
 public class ClientTick implements Runnable
 {
-    private static final Minecraft mc = Minecraft.getMinecraft();
-	private static long nextTimeMs = System.currentTimeMillis();
-	private static final int delayMs = 200;
-	private Thread thread = null;
+	private static final Minecraft mc = Minecraft.getMinecraft();
 
-	@SubscribeEvent
-	public void tickEnd( TickEvent.ClientTickEvent event )
-	{
-		if ( (event.phase == TickEvent.Phase.END) && (mc.player != null) )
-		{
-			XRay.localPlyX = MathHelper.floor( mc.player.posX );
-			XRay.localPlyY = MathHelper.floor( mc.player.posY );
-			XRay.localPlyZ = MathHelper.floor( mc.player.posZ );
-            XRay.localPlyXPrev = MathHelper.floor( mc.player.prevPosX );
-            XRay.localPlyZPrev = MathHelper.floor( mc.player.prevPosZ );
-
-			if( XRay.drawOres && ((this.thread == null) || !this.thread.isAlive()) &&
-			( (mc.world != null) && (mc.player != null) ) ) // If we're in a world and want to start drawing create the thread.
-			{
-				this.thread = new Thread( this );
-				this.thread.setDaemon( false );
-				this.thread.setPriority( Thread.MAX_PRIORITY );
-				this.thread.start();
-			}
-		}
-	}
-
-
-	@Override
+        @Override
 	public void run() // Our thread code for finding ores near the player.
 	{
-		try
-		{
-			while( !this.thread.isInterrupted() ) // Check the internal interrupt flag. Exit thread if set.
+                blockFinder();
+                XRay.instance.doneFindingBlocks(); // Inform the mod that we're done finding blocks
+	}
+
+	/**
+	 * Should only be called by requestBlockFinder() as it manages the
+	 * threads and checks the preconditions (drawOres, player not null ...)
+	 */
+	private void blockFinder() {
+
+		final int px = XRay.localPlyX;
+		final int py = XRay.localPlyY;
+		final int pz = XRay.localPlyZ;
+		if ( px == XRay.localPlyXPrev && pz == XRay.localPlyZPrev && XrayRenderer.ores.size() > 0 ) {
+			return; // Skip the check if the player hasn't moved
+		}
+		final List<BlockInfo> temp = new ArrayList<>();
+		final int radius = XRay.distNumbers[ XRay.currentDist ]; // Get the radius around the player to search.
+
+		final Map<OreInfo, int[]> ores = new HashMap<>(); // Searches in Set/Map are faster than looping on List
+		for ( OreInfo ore : XRay.searchList ) {
+			if ( ore.draw ) // We can handle this condition right here rather than doing it in the big loop
 			{
-				if( blockFinder( false ) )
-                    Thread.sleep(1000);
-                else
-                    this.thread.interrupt(); // Kill the thread if we turn off xray or the player/world object becomes null.
-            }
-			//System.out.println(" --- Thread Exited Cleanly! ");
-			this.thread = null;
+				ores.put( ore, ore.color ); // Using a Map to get the ore color since Set does not have a get() method
+			}
 		}
-		catch ( Exception exc )
+		final OreInfo buff = new OreInfo( 0, 0 ); // Search key for the map
+
+		final int minX = px - radius;
+		final int maxX = px + radius;
+		final int minY = Math.max(0, py - 92);
+		final int maxY = Math.min(255, py + 32);
+		final int minZ = pz - radius;
+		final int maxZ = pz + radius;
+		int lowBoundX, highBoundX, lowBoundY, highBoundY, lowBoundZ, highBoundZ;
+
+		// Loop on chunks (x, z)
+		for ( int chunkX = (minX >> 4); chunkX <= (maxX >> 4); chunkX++ ) // Using bitshift because negative numbers divided by 16 will give a wrong chunk
 		{
-			System.out.println(" ClientTick Thread Interrupted!!! " + exc.toString() ); // This shouldnt get called.
+			// Pre-compute the extend bounds on X
+			int x = chunkX << 4; // lowest x coord of the chunk in block/world coordinates
+			lowBoundX = (x < minX) ? minX - x : 0; // lower bound for x within the extend
+			highBoundX = (x + 15 > maxX) ? maxX - x : 15;// and higher bound. Basically, we clamp it to fit the radius.
+
+			for ( int chunkZ = (minZ >> 4); chunkZ <= (maxZ >> 4); chunkZ++ )
+			{
+				// Time to get the chunk (16x256x16) and split it into 16 vertical extends (16x16x16)
+				Chunk chunk = mc.world.getChunkFromChunkCoords( chunkX, chunkZ );
+				if ( chunk == null || !chunk.isLoaded() ) {
+					continue; // We won't find anything interesting in unloaded chunks
+				}
+				ExtendedBlockStorage[] extendsList = chunk.getBlockStorageArray();
+
+				// Pre-compute the extend bounds on Z
+				int z = chunkZ << 4;
+				lowBoundZ = (z < minZ) ? minZ - z : 0;
+				highBoundZ = (z + 15 > maxZ) ? maxZ - z : 15;
+
+				// Loop on the extends around the player's layer (6 down, 2 up)
+				for ( int curExtend = (minY >> 4); curExtend <= (maxY >> 4); curExtend++ )
+				{
+					ExtendedBlockStorage ebs = extendsList[curExtend];
+					if (ebs == null) // happens quite often!
+						continue;
+
+					// Pre-compute the extend bounds on Y
+					int y = curExtend << 4;
+					lowBoundY = (y < minY) ? minY - y : 0;
+					highBoundY = (y + 15 > maxY) ? maxY - y : 15;
+
+					// Now that we have an extend, let's check all its blocks
+					for ( int i = lowBoundX; i <= highBoundX; i++ ) {
+						for ( int j = lowBoundY; j <= highBoundY; j++ ) {
+							for ( int k = lowBoundZ; k <= highBoundZ; k++ ) {
+								IBlockState state = ebs.get( i, j, k ); // this one seems a lot faster than asking the world directly
+
+								Block block = state.getBlock();
+								buff.id = Block.getIdFromBlock( block );      // prepare the search key according to OreInfo.equals()
+								buff.meta = block.getMetaFromState( state );  // and OreInfo.hashCode()
+
+								if (block.hasTileEntity( state )) {
+									buff.meta = 0;
+								}
+
+								if (ores.containsKey( buff )) // The reason for using Set/Map
+								{
+									temp.add( new BlockInfo(x + i, y + j, z + k, ores.get(buff)) ); // Add this block to the temp list using world coordinates
+								}
+							}
+						}
+					}
+				}
+			}
 		}
+
+		XrayRenderer.ores.clear();
+		XrayRenderer.ores.addAll( temp ); // Add all our found blocks to the XrayRenderer.ores list. To be use by XrayRenderer when drawing.
+
 	}
-
-	public static boolean blockFinder(boolean ForceAdd) {
-		if (XRay.drawOres && !XRay.searchList.isEmpty() && mc.world != null && mc.player != null)
-		{
-			if ( nextTimeMs > System.currentTimeMillis() ) // Delay to avoid spamming ore updates.
-				return true;
-
-			final int px = XRay.localPlyX;
-			final int py = XRay.localPlyY;
-			final int pz = XRay.localPlyZ;
-			if( ( ( px == XRay.localPlyXPrev && pz == XRay.localPlyZPrev ) && XrayRenderer.ores.size() > 0 ) && !ForceAdd )
-				return true; // Skip the check if the player hasn't moved
-
-			final List<BlockInfo> temp = new ArrayList<>();
-			final int radius = XRay.distNumbers[ XRay.currentDist]; // Get the radius around the player to search.
-
-                        final Map<OreInfo, int[]> ores = new HashMap<>(); // Searches in Set/Map are faster than looping on List
-                        for( OreInfo ore : XRay.searchList )
-                        {
-                                if ( ore.draw ) // We can handle this condition right here rather than doing it in the big loop
-                                {
-                                        ores.put( ore, ore.color ); // Using a Map to get the ore color since Set does not have a get() method
-                                }
-                        }
-                        final OreInfo buff = new OreInfo( 0, 0 ); // Search key for the map
-
-                        final int minX = px - radius;
-                        final int maxX = px + radius;
-                        final int minY = Math.max( 0, py - 92 );
-                        final int maxY = Math.min( 255, py + 32 );
-                        final int minZ = pz - radius;
-                        final int maxZ = pz + radius;
-                        int lowBoundX, highBoundX, lowBoundY, highBoundY, lowBoundZ, highBoundZ;
-
-                        // Loop on chunks (x, z)
-                        for ( int chunkX = (minX >> 4); chunkX <= (maxX >> 4); chunkX++ ) // Using bitshift because negative numbers divided by 16 will give a wrong chunk
-                        {
-                                // Pre-compute the extend bounds on X
-                                int x = chunkX << 4; // lowest x coord of the chunk in block/work coordinates
-                                lowBoundX = ( x < minX ) ? minX - x : 0; // lower bound for x within the extend
-                                highBoundX = ( x + 15 > maxX ) ? maxX - x : 15;// and higher bound. Basically, we clamp it to fit the radius.
-
-                                for ( int chunkZ = (minZ >> 4); chunkZ <= (maxZ >> 4); chunkZ++ )
-                                {
-                                        // Time to get the chunk (16x256x16) and split it into 16 vertical extends (16x16x16)
-                                        Chunk chunk = mc.world.getChunkFromChunkCoords( chunkX, chunkZ );
-                                        if ( chunk == null || !chunk.isLoaded() ) {
-                                                continue;
-                                        }
-                                        ExtendedBlockStorage[] extendsList = chunk.getBlockStorageArray();
-
-                                        // Pre-compute the extend bounds on Z
-                                        int z = chunkZ << 4;
-                                        lowBoundZ = ( z < minZ ) ? minZ - z : 0;
-                                        highBoundZ = ( z + 15> maxZ ) ? maxZ - z : 15;
-
-                                        // Loop on the extends around the player's layer (6 down, 2 up)
-                                        for ( int curExtend = (minY >> 4); curExtend <= (maxY >> 4); curExtend++ )
-                                        {
-                                                ExtendedBlockStorage ebs = extendsList[curExtend];
-                                                if ( ebs == null ) { // happens quite often!
-                                                        continue;
-                                                }
-
-                                                // Pre-compute the extend bounds on Y
-                                                int y = curExtend << 4;
-                                                lowBoundY = ( y < minY ) ? minY - y : 0;
-                                                highBoundY = ( y + 15 > maxY ) ? maxY - y : 15;
-
-                                                // Now that we have an extend, let's check all its blocks
-                                                for ( int i = lowBoundX; i <= highBoundX; i++ )
-                                                {
-                                                        for ( int j = lowBoundY; j <= highBoundY; j++ )
-                                                        {
-                                                                for ( int k = lowBoundZ; k <= highBoundZ; k++ )
-                                                                {
-                                                                        IBlockState state = ebs.get(i, j, k); // this one seems a lot faster than asking the world directly
-
-                                                                        Block block = state.getBlock();
-                                                                        buff.id = Block.getIdFromBlock( block );
-                                                                        buff.meta = block.getMetaFromState( state );
-
-                                                                        if( block.hasTileEntity( state ) )
-                                                                                buff.meta = 0;
-
-                                                                        if ( ores.containsKey(buff) ) // The reason for using Set/Map
-                                                                        {
-                                                                                temp.add( new BlockInfo( x + i, y + j, z + k, ores.get(buff)) ); // Add this block to the temp list using world coordinates
-                                                                        }
-                                                                }
-                                                        }
-                                                }
-                                        }
-                                }
-                        }
-
-			XrayRenderer.ores.clear();
-			XrayRenderer.ores.addAll(temp); // Add all our found blocks to the XrayRenderer.ores list. To be use by XrayRenderer when drawing.
-			nextTimeMs = System.currentTimeMillis() + delayMs; // Update the delay.
-		}
-		else
-		    return false;
-
-		return true;
-	}
-
 }

--- a/src/main/java/com/xray/client/render/XrayRenderer.java
+++ b/src/main/java/com/xray/client/render/XrayRenderer.java
@@ -6,20 +6,22 @@ import com.xray.common.utils.Utils;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.Tessellator;
-import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
-import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import org.lwjgl.opengl.GL11;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.event.world.BlockEvent;
+import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 // TODO: Please refactor of all this file :heart:
 public class XrayRenderer
 {
 	private final Minecraft mc = Minecraft.getMinecraft();
-	public static List<BlockInfo> ores = new ArrayList<>();
+	public static List<BlockInfo> ores = Collections.synchronizedList( new ArrayList<>() ); // this is accessed by threads
 
 	// Opacity is weird as all hell. We save it as 0 - 1 / off -> full so we need to convert that value
 	private static float opacity = ( XRay.outlineOpacity > 1 ? 255 : XRay.outlineOpacity < 0 ? 1 : ( XRay.outlineOpacity  * 255 ) ); // Pretty simple :D
@@ -27,7 +29,7 @@ public class XrayRenderer
 	@SubscribeEvent
 	public void onWorldRenderLast( RenderWorldLastEvent event ) // Called when drawing the world.
 	{
-		if ( mc.world != null && XRay.drawOres )
+		if ( mc.world != null && XRay.drawOres() )
 		{
 			float f = event.getPartialTicks();
 
@@ -40,21 +42,30 @@ public class XrayRenderer
 		}
 	}
 
-    @SubscribeEvent
-    public void pickupItem( BlockEvent.BreakEvent event ) {
-        if ( mc.world != null && XRay.drawOres )
-        {
-            ClientTick.blockFinder( true );
-        }
-    }
+	@SubscribeEvent
+	public void tickEnd( TickEvent.ClientTickEvent event )
+	{
+		if ( (event.phase == TickEvent.Phase.END) && (mc.player != null) )
+		{
+			XRay.localPlyX = MathHelper.floor( mc.player.posX );
+			XRay.localPlyY = MathHelper.floor( mc.player.posY );
+			XRay.localPlyZ = MathHelper.floor( mc.player.posZ );
+			XRay.localPlyXPrev = MathHelper.floor( mc.player.prevPosX );
+			XRay.localPlyZPrev = MathHelper.floor( mc.player.prevPosZ );
 
-    @SubscribeEvent
-    public void placeItem(BlockEvent.PlaceEvent event ) {
-        if ( mc.world != null && XRay.drawOres )
-        {
-            ClientTick.blockFinder( true );
-        }
-    }
+			XRay.requestBlockFinder( false );
+		}
+	}
+
+	@SubscribeEvent
+	public void pickupItem( BlockEvent.BreakEvent event ) {
+		XRay.requestBlockFinder( true );
+	}
+
+	@SubscribeEvent
+	public void placeItem(BlockEvent.PlaceEvent event ) {
+		XRay.requestBlockFinder( true );
+	}
 
 	private void drawOres( float playerX, float playerY, float playerZ )
 	{
@@ -71,7 +82,7 @@ public class XrayRenderer
 
 		ArrayList<BlockInfo> temp = new ArrayList<>();
 		temp.addAll(ores);
-		
+
 		for ( BlockInfo b : temp )
 		{
 		    if( b == null )
@@ -91,7 +102,7 @@ public class XrayRenderer
 			);
 
 		}
-		
+
 		GL11.glDepthMask(true);
 		GL11.glDisable( GL11.GL_BLEND );
 		GL11.glEnable( GL11.GL_TEXTURE_2D );

--- a/src/main/java/com/xray/client/render/XrayRenderer.java
+++ b/src/main/java/com/xray/client/render/XrayRenderer.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import net.minecraft.util.math.MathHelper;
-import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 
 // TODO: Please refactor of all this file :heart:
@@ -57,16 +56,6 @@ public class XrayRenderer
 		}
 	}
 
-	@SubscribeEvent
-	public void pickupItem( BlockEvent.BreakEvent event ) {
-		XRay.requestBlockFinder( true );
-	}
-
-	@SubscribeEvent
-	public void placeItem(BlockEvent.PlaceEvent event ) {
-		XRay.requestBlockFinder( true );
-	}
-
 	private void drawOres( float playerX, float playerY, float playerZ )
 	{
 		GL11.glDisable( GL11.GL_TEXTURE_2D );
@@ -91,9 +80,9 @@ public class XrayRenderer
 			Utils.renderBlockBounding(
 				tessellator,
 				buffer,
-				b.x-playerX,
-				b.y-playerY,
-				b.z-playerZ,
+				b.getX()-playerX,
+				b.getY()-playerY,
+				b.getZ()-playerZ,
 				b.color[0],
 				b.color[1],
 				b.color[2],

--- a/src/main/java/com/xray/common/proxy/ClientProxy.java
+++ b/src/main/java/com/xray/common/proxy/ClientProxy.java
@@ -5,7 +5,6 @@ import com.xray.client.KeyBindingHandler;
 import com.xray.client.render.ClientTick;
 import com.xray.client.render.XrayRenderer;
 import com.xray.common.XRay;
-import com.xray.common.proxy.CommonProxy;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.client.registry.ClientRegistry;

--- a/src/main/java/com/xray/common/proxy/ClientProxy.java
+++ b/src/main/java/com/xray/common/proxy/ClientProxy.java
@@ -2,6 +2,7 @@
 package com.xray.common.proxy;
 
 import com.xray.client.KeyBindingHandler;
+import com.xray.client.XRayEventHandler;
 import com.xray.client.render.ClientTick;
 import com.xray.client.render.XrayRenderer;
 import com.xray.common.XRay;
@@ -27,7 +28,7 @@ public class ClientProxy extends CommonProxy
 		}
 
 		MinecraftForge.EVENT_BUS.register( new KeyBindingHandler() );
-		MinecraftForge.EVENT_BUS.register( new ClientTick() );
+		MinecraftForge.EVENT_BUS.register( new XRayEventHandler() );
 		MinecraftForge.EVENT_BUS.register( new XrayRenderer() );	// XrayRenderer is forge subscribed to onRenderEvent. Which is called when drawing the world.
 	}
 

--- a/src/main/java/com/xray/common/reference/BlockInfo.java
+++ b/src/main/java/com/xray/common/reference/BlockInfo.java
@@ -1,15 +1,20 @@
 package com.xray.common.reference;
 
-public class BlockInfo
+import net.minecraft.util.math.Vec3i;
+
+public class BlockInfo extends Vec3i // so we benefit from Vec3i's hashCode() and equals()
 {
-	public int x, y, z;
 	public int[] color;
-	
+
 	public BlockInfo( int bx, int by, int bz, int[] c )
 	{
-		this.x = bx;
-		this.y = by;
-		this.z = bz;
+		super( bx, by, bz );
 		this.color = c;
 	}
+
+	public BlockInfo( Vec3i pos, int[] c )
+	{
+		this( pos.getX(), pos.getY(), pos.getZ(), c );
+	}
+
 }


### PR DESCRIPTION
Here is a pull request concerning the thread optimization discussed in #43 
I put it here so you can review and comment it.

I just revamped placeItem and pickupItem events so we don't run blockFinder here: from the event, we know a single block was added or removed, so we can just alter the ore list accordingly. Saves quite a lot on large radius :)

I derived BlockInfo from Vec3i, which also contains 3 int coordinates (so the object has still the same memory size). That way, we don't even have to implement equals() and hashCode() to use them in List or Set.
Are we drawing a block at BlockPos pos?
`XRayRenderer.ores.contains( new BlockInfo(pos) );`

I've done a lot more tests, breaking and placing blocks while sprinting around, with a small and large radius, it looks pretty solid. I haven't spotted any bug yet. If you find any, please let me know.

It may be theoretically possible to place a block while moving without XRay drawing it. It has to occur right after you moved 1 block away (starts the thread), after the thread scanned the block position and before it clears the ore list. The timing is extremely short (a few milliseconds). I have tried for half an hour and couldn't do it so even if it's theoretically possible, it doesn't seem possible in a real world.
Not to mention that:
- with a radius < 256 the timing is physically too short
- moving fast and placing a block means, because of inertia, you will trigger another thread run which will fix it
- who wants to place a block being xrayed while sprinting anyway?
- the block you placed really doesn't need to be drawn: you know where it is since you just placed it and it's right in front of you! :)

Anyway, if that _ever_ happens, the block gets drawn normally on the next thread run. Preventing this bug completely would require to synchronize the thread on XRayRenderer.ores which would hurt the performance very badly for no good reason (and actually freeze the game for a few ticks when placing/destroying a block while moving ...).