### PR TITLE
Fixed a bug with ore dictionary detection.

### DIFF
--- a/src/main/java/com/xray/common/XRay.java
+++ b/src/main/java/com/xray/common/XRay.java
@@ -74,14 +74,14 @@ public class XRay
 	@EventHandler
 	public void init(FMLInitializationEvent event)
 	{
-		ConfigHandler.setup(); // Read the config file and setup environment.
-
 		proxy.init( event );
 	}
 
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent event)
 	{
+		ConfigHandler.setup(); // Read the config file and setup environment.
+
 		for ( Block block : ForgeRegistries.BLOCKS ) {
 			NonNullList<ItemStack> subBlocks = NonNullList.create();
 			block.getSubBlocks( block.getCreativeTabToDisplayOn(), subBlocks );


### PR DESCRIPTION
Some ores loaded from the config are correctly marked as useoredict
but the substitution ores don't show up until the config gets modified.

Cause: some mods register their ores during the init() phase
Solution: simply load the config during postinit()

---
Side note: I've been working on improving the rendering lately but I haven't found a suitable solution yet. I've tried tons of things, the sweeter idea being the use MC's block rendering which enables many features (easy and readable code, can display outlines, textures, cull faces and edges, etc.) but is dramatically slow. Also, it creates issues with block lighting and block side drawing. Could be good for entities though.

For now the only noticeable improvement is to sort the ores to draw so that far blocks are rendered first. This creates some kind of depth buffer on our wireframe blocks which makes them display nicer. I still have to test this on big radius on my very slow laptop to record the computation cost. BlockFinder, which runs in a thread, is probably the best place to sort the ores as it should hurt the overall performance.

If you want to try it out, add this to blockFinder() near the end, right before you clear the 'ores' variable:

`final BlockPos playerPos = mc.player.getPosition();`
`Collections.sort(temp, new Comparator<BlockInfo>() {`
`  @Override`
`  public int compare(BlockInfo t, BlockInfo t1) {`
`    return Double.compare( t1.distanceSq(playerPos), t.distanceSq(playerPos) );`
`  }`
`});`
