### PR TITLE
A Couple of Fixes

### DIFF
--- a/src/main/java/com/xray/client/xray/XrayController.java
+++ b/src/main/java/com/xray/client/xray/XrayController.java
@@ -38,14 +38,13 @@ public class XrayController
 		if ( !drawOres ) // enable drawing
 		{
 			XrayRenderer.ores.clear(); // first, clear the buffer
-			drawOres = true; // then, enable drawing
 			executor = Executors.newSingleThreadExecutor();
+			drawOres = true; // then, enable drawing
 			requestBlockFinder( true ); // finally, force a refresh
 		}
 		else // disable drawing
 		{
-			drawOres = false;
-			executor.shutdownNow(); // no need to have a thread pool running if we don't draw ores
+			shutdownExecutor();
 		}
 	}
 	public static int getCurrentDist() { return currentDist; }
@@ -108,5 +107,16 @@ public class XrayController
 			WorldRegion region = new WorldRegion( lastPlayerPos, getRadius() ); // the region to scan for ores
 			task = executor.submit( new ClientTick(region) );
 		}
+	}
+
+	/**
+	 * To be called at least when the game shutsdown
+	 */
+	public static void shutdownExecutor()
+	{
+		// Important. If drawOres is true when a player logs out then logs back in, the next requestBlockFinder will crash
+		drawOres = false;
+		try { executor.shutdownNow(); }
+		catch (Throwable ignore) {}
 	}
 }

--- a/src/main/java/com/xray/common/XRay.java
+++ b/src/main/java/com/xray/common/XRay.java
@@ -1,6 +1,5 @@
 package com.xray.common;
 
-import com.xray.common.config.ConfigHandler;
 import com.xray.common.proxy.CommonProxy;
 import com.xray.common.reference.BlockId;
 import com.xray.common.reference.OreInfo;
@@ -20,12 +19,8 @@ import org.lwjgl.input.Keyboard;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
-import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
-import net.minecraft.init.Blocks;
-import net.minecraft.item.ItemStack;
-import net.minecraft.util.NonNullList;
-import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
 import org.apache.logging.log4j.Logger;
 
 @Mod(modid= Reference.MOD_ID, name= Reference.MOD_NAME, version=Reference.MOD_VERSION /*guiFactory = Reference.GUI_FACTORY*/)
@@ -65,7 +60,6 @@ public class XRay
 	public void preInit(FMLPreInitializationEvent event)
 	{
 		logger = event.getModLog();
-		ConfigHandler.init(event.getSuggestedConfigurationFile());
 
 		logger.debug(I18n.format("xray.debug.init"));
 		proxy.preInit( event );
@@ -80,23 +74,12 @@ public class XRay
 	@EventHandler
 	public void postInit(FMLPostInitializationEvent event)
 	{
-		ConfigHandler.setup(); // Read the config file and setup environment.
-
-		for ( Block block : ForgeRegistries.BLOCKS ) {
-			NonNullList<ItemStack> subBlocks = NonNullList.create();
-			block.getSubBlocks( block.getCreativeTabToDisplayOn(), subBlocks );
-			if ( Blocks.AIR.equals( block ) )
-				continue; // avoids troubles
-
-			for( ItemStack subBlock : subBlocks ) {
-				String name = subBlock.isEmpty() ? block.getRegistryName().toString() : subBlock.getItem().getRegistryName().toString();
-				int meta	= subBlock.isEmpty() ? 0 : subBlock.getItemDamage();
-
-				if ( Block.getBlockFromName(name) != null ) // some blocks like minecraft:banner return null and break everything
-					blockList.add( new OreInfo( name, meta ) );
-			}
-		}
 		proxy.postInit( event );
 	}
 
+	@EventHandler
+	public void onExit(FMLServerStoppingEvent event)
+	{
+		proxy.onExit(event);
+	}
 }

--- a/src/main/java/com/xray/common/proxy/ClientProxy.java
+++ b/src/main/java/com/xray/common/proxy/ClientProxy.java
@@ -2,20 +2,31 @@
 package com.xray.common.proxy;
 
 import com.xray.client.KeyBindingHandler;
+import com.xray.client.xray.XrayController;
 import com.xray.client.xray.XrayEventHandler;
 import com.xray.common.XRay;
+import com.xray.common.config.ConfigHandler;
+import com.xray.common.reference.OreInfo;
+import net.minecraft.block.Block;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.NonNullList;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.client.registry.ClientRegistry;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
 
 public class ClientProxy extends CommonProxy
 {
 	@Override
 	public void preInit(FMLPreInitializationEvent event) {
 		super.preInit(event);
+
+		ConfigHandler.init( event.getSuggestedConfigurationFile() );
 
 		// Setup Keybindings
 		XRay.keyBind_keys = new KeyBinding[ XRay.keyBind_descriptions.length ];
@@ -32,11 +43,33 @@ public class ClientProxy extends CommonProxy
 	@Override
 	public void init(FMLInitializationEvent event) {
 		super.init(event);
+
+		for ( Block block : ForgeRegistries.BLOCKS ) {
+			NonNullList<ItemStack> subBlocks = NonNullList.create();
+			block.getSubBlocks( block.getCreativeTabToDisplayOn(), subBlocks );
+			if ( Blocks.AIR.equals( block ) )
+				continue; // avoids troubles
+
+			for( ItemStack subBlock : subBlocks ) {
+				String name = subBlock.isEmpty() ? block.getRegistryName().toString() : subBlock.getItem().getRegistryName().toString();
+				int meta	= subBlock.isEmpty() ? 0 : subBlock.getItemDamage();
+
+				if ( Block.getBlockFromName(name) != null ) // some blocks like minecraft:banner return null and break everything
+					XRay.blockList.add( new OreInfo( name, meta ) );
+			}
+		}
 	}
 
 	@Override
 	public void postInit(FMLPostInitializationEvent event) {
 		super.postInit(event);
+
+		ConfigHandler.setup(); // Read the config file and setup environment.
 	}
 
+	@Override
+	public void onExit(FMLServerStoppingEvent event)
+	{
+		XrayController.shutdownExecutor(); // Make sure threads don't lock the JVM
+	}
 }

--- a/src/main/java/com/xray/common/proxy/ClientProxy.java
+++ b/src/main/java/com/xray/common/proxy/ClientProxy.java
@@ -43,6 +43,13 @@ public class ClientProxy extends CommonProxy
 	@Override
 	public void init(FMLInitializationEvent event) {
 		super.init(event);
+	}
+
+	@Override
+	public void postInit(FMLPostInitializationEvent event) {
+		super.postInit(event);
+
+		ConfigHandler.setup(); // Read the config file and setup environment.
 
 		for ( Block block : ForgeRegistries.BLOCKS ) {
 			NonNullList<ItemStack> subBlocks = NonNullList.create();
@@ -58,13 +65,6 @@ public class ClientProxy extends CommonProxy
 					XRay.blockList.add( new OreInfo( name, meta ) );
 			}
 		}
-	}
-
-	@Override
-	public void postInit(FMLPostInitializationEvent event) {
-		super.postInit(event);
-
-		ConfigHandler.setup(); // Read the config file and setup environment.
 	}
 
 	@Override

--- a/src/main/java/com/xray/common/proxy/CommonProxy.java
+++ b/src/main/java/com/xray/common/proxy/CommonProxy.java
@@ -3,6 +3,7 @@ package com.xray.common.proxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
 
 public class CommonProxy {
     public void preInit(FMLPreInitializationEvent event) {
@@ -12,5 +13,8 @@ public class CommonProxy {
     }
 
     public void postInit(FMLPostInitializationEvent event) {
+    }
+
+    public void onExit(FMLServerStoppingEvent event) {
     }
 }

--- a/src/main/java/com/xray/common/proxy/ServerProxy.java
+++ b/src/main/java/com/xray/common/proxy/ServerProxy.java
@@ -3,6 +3,7 @@ package com.xray.common.proxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.event.FMLServerStoppingEvent;
 
 public class ServerProxy extends CommonProxy
 {
@@ -19,5 +20,10 @@ public class ServerProxy extends CommonProxy
 	@Override
 	public void postInit(FMLPostInitializationEvent event) {
 	    super.postInit(event);
+	}
+
+	@Override
+	public void onExit(FMLServerStoppingEvent event) {
+		super.onExit(event);
 	}
 }


### PR DESCRIPTION
I have moved some code from XRay to the client proxy: config loading and block loading. That way, if someone puts the mod on a server, that server won't scan blocks for nothing.

More important, I have added a shutdown hook to ensure any running threads are stopped when the game closes. Depending on the platform, JVM, and game launcher, it was possible for ExecutorService to prevent Java from closing properly. This should be solved now.

Also, XRay now disables drawing ores (and threads) when the player exits the game to the main menu. Before, leaving the current game while XRay was on and then re-entering the world could crash the game.
